### PR TITLE
Update readme.md -- hash digest iteration table has an error

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -199,7 +199,7 @@ These test vectors reflect the required hash digest iterations for a variety of 
 | 120                    | 3                 |
 | 183                    | 3                 |
 | 184                    | 4                 |
-| 247                    | 5                 |
+| 247                    | 4                 |
 | 248                    | 5                 |
 | 488                    | 8                 |
 | 503                    | 8                 |


### PR DESCRIPTION
The table has an error for `247`, which should be 4, not 5. 248 hits the 5 threshold. Likely this was just a mental error when you were composing the table.

247 + 8 -> 255 -> 255 / 64 -> 3 ... then add 1 to 3 you get 4.