### PR TITLE
fix js operation cost limit

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -275,7 +275,7 @@ int max_operation_cost (int unlocking_bytecode_length) {
 
 ```js
 const maxOperationCost = (unlockingBytecodeLength) =>
-  Math.floor((41 + unlockingBytecodeLength) * 800);
+  (41 + unlockingBytecodeLength) * 800;
 ```
 
 </details>


### PR DESCRIPTION
As I'm sure you know, this calculation is different from the others that use `floor()`. Although it will result in the correct outputs given the possible range of inputs, it gives a wrong impression that I think should be fixed one way or the other.

The other calculations use `floor()` to emulate integer division and are entirely appropriate / necessary. However, here there is an integer multiplication that, given the range of values (far within 53 bits), will always result in an integer result for javascript floats.

Therefore, the `floor()` is technically harmless in this case. However, it suggests emulating integer math, which either:

a) isn't necessary (within the range of valid inputs) or
b) is wrong in the hypothetical case (outside the valid range of inputs) of very large numbers where float precision would be the only issue and `round()` would be the correct approach

In the case of prioritizing a), I would recommend to just remove the floor so as not to give the wrong impression or look naive.

In the case of prioritizing b), float precision, the correct approach is to round. E.g. in the case of `intA * intB --> 1.999999999`, the correct integer multiplication result is 2 (result of rounding), not 1 (result of floor).

In this MR, I chose a) in order to avoid the introduction of unnecessary concepts (float precision). However, if my understanding is wrong and within the range boundaries it is actually possible to have precision issues, then the status quo and option a) are both strictly incorrect and b) must be used.