### PR TITLE
fix truncation and precision ambiguities in javascript examples

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -150,9 +150,9 @@ int max_consensus_iterations (int unlocking_bytecode_length) {
 
 ```js
 const maxStandardIterations = (unlockingBytecodeLength) =>
-  Math.floor((41 + unlockingBytecodeLength) / 2);
+  (41n + unlockingBytecodeLength) / 2n;
 const maxConsensusIterations = (unlockingBytecodeLength) =>
-  Math.floor(((41 + unlockingBytecodeLength) * 7) / 2);
+  ((41n + unlockingBytecodeLength) * 7n) / 2n;
 ```
 
 </details>
@@ -178,7 +178,7 @@ Note that the double-hashing operations (`OP_HASH160` and `OP_HASH256`) and all 
 
 ```js
 const digestIterations = (messageLength, isDouble) =>
-  1 + Math.floor((messageLength + 8) / 64) + (isDouble ? 1 : 0);
+  1n + ((messageLength + 8n) / 64n) + (isDouble ? 1n : 0n);
 ```
 
 </details>
@@ -275,7 +275,7 @@ int max_operation_cost (int unlocking_bytecode_length) {
 
 ```js
 const maxOperationCost = (unlockingBytecodeLength) =>
-  Math.floor((41 + unlockingBytecodeLength) * 800);
+  (41n + unlockingBytecodeLength) * 800n;
 ```
 
 </details>


### PR DESCRIPTION
I had filed #26 in order to fix an ambiguity or perception of error in the javascript example that has integer multiplication without division.

However, in order to remove all ambiguity and represent the intent even more clearly, I propose to make all the javascript examples use bigint.

The issues:

## 1. Using floor() to emulate integer division truncation for positive numbers

This is a very common approach. It's probably even safe. It's definitely safe for results that are nominally not integers, e.g. `5 / 3`. However, I don't know the float spec well enough to know if there is room for precision issues in the case of nominally integer results. E.g. `555 / 5 = 111` nominally, but are there division inputs within the possible range that result in `555 / 5 = 110.99999999` where `floor()` would create the wrong result? I don't know. Using bigint removes that ambiguity.

## 1. Using round() to resolve epsilon-type precision issues

When the nominal result of a float math operation is expected to be an integer, `round()` is typically used to remove any epsilon and get the integer result. This was the motivation for #26 where `floor()` was being used in a place that `round()` would typically be used to correct for any epsilon. Using bigint removes this ambiguity also.


